### PR TITLE
Add JSON report and PNG default plot format to output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/__pycache__
 src/smudgeplot/__pycache__
 src/smudgeplot.egg-info
 dist
+.venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,35 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "ARG",
+    "B",
+    "BLE",
+    "C4",
+    "COM",
+    "DTZ",
+    "E",
+    "EM",
+    "F",
+    "I",
+    "ISC",
+    "LOG",
+    "N",
+    "PYI",
+    "S",
+    "SIM",
+    "U",
+]
+ignore = [
+    "COM812",
+    "C901",
+    "LOG015",
+    "N803",
+    "N806",
+]

--- a/src/smudgeplot/cli.py
+++ b/src/smudgeplot/cli.py
@@ -213,6 +213,12 @@ class Parser:
             default=False,
             help="Revert the colour palette (default False).",
         )
+        argparser.add_argument(
+            "--format",
+            default="pdf",
+            help="Output format for the plots (default pdf)",
+            choices=["pdf", "png"],
+        )
         return argparser
 
 
@@ -309,7 +315,7 @@ def main():
                 cov = 0
 
             sys.stderr.write("\nCreating centrality plot\n")
-            smudges.centrality_plot(args.o)
+            smudges.centrality_plot(args.o, args.format)
             sys.stderr.write(f"\nInferred coverage: {cov:.3f}\n")
 
         else:
@@ -329,7 +335,7 @@ def main():
 
         smg.generate_smudge_report(smudges, coverages, cov, args, smudge_size_cutoff, print_header=True)
         sys.stderr.write("\nCreating smudgeplots\n")
-        smg.generate_plots(smudges, coverages, cov, smudge_size_cutoff, args.o, title)
+        smg.generate_plots(smudges, coverages, cov, smudge_size_cutoff, args.o, title, format=args.format)
 
     fin()
 

--- a/src/smudgeplot/cli.py
+++ b/src/smudgeplot/cli.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
-import sys
 import argparse
-import numpy as np
+import sys
 from os import system
+
+import numpy as np
+
 import smudgeplot.smudgeplot as smg
+
 
 class Parser:
     def __init__(self):

--- a/src/smudgeplot/cli.py
+++ b/src/smudgeplot/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import sys
+from importlib.metadata import version
 from os import system
 
 import numpy as np
@@ -221,6 +222,12 @@ class Parser:
             help="Output format for the plots (default pdf)",
             choices=["pdf", "png"],
         )
+        argparser.add_argument(
+            "--json_report",
+            action="store_true",
+            default=False,
+            help="Generate a JSON format report alongside the plots (default False)",
+        )
         return argparser
 
 
@@ -232,8 +239,8 @@ def fin():
 def main():
     _parser = Parser()
 
-    version = "0.5.0 skylight"
-    sys.stderr.write("Running smudgeplot v" + version + "\n")
+    smdg_v = version("smudgeplot")
+    sys.stderr.write(f"Running smudgeplot v{smdg_v}\n")
     if _parser.task == "version":
         exit(0)
 
@@ -325,7 +332,7 @@ def main():
             sys.stderr.write(f"\nUser defined coverage: {cov:.3f}\n")
 
         sys.stderr.write("\nCreating smudge report\n")
-        
+
         smudges.local_agg_smudge_container = smudges.get_smudge_container(cov, smudge_size_cutoff, "local_aggregation")
         annotated_smudges = list(smudges.local_agg_smudge_container.keys())
         with open(args.o + "_with_annotated_smu.txt", "w") as annotated_smu:
@@ -337,7 +344,16 @@ def main():
 
         smg.generate_smudge_report(smudges, coverages, cov, args, smudge_size_cutoff, print_header=True)
         sys.stderr.write("\nCreating smudgeplots\n")
-        smg.generate_plots(smudges, coverages, cov, smudge_size_cutoff, args.o, title, format=args.format)
+        smg.generate_plots(
+            smudges,
+            coverages,
+            cov,
+            smudge_size_cutoff,
+            args.o,
+            title,
+            fmt=args.format,
+            json_report=args.json_report,
+        )
 
     fin()
 

--- a/src/smudgeplot/cli.py
+++ b/src/smudgeplot/cli.py
@@ -219,7 +219,7 @@ class Parser:
         )
         argparser.add_argument(
             "--format",
-            default="pdf",
+            default="png",
             help="Output format for the plots (default pdf)",
             choices=["pdf", "png"],
         )
@@ -273,7 +273,7 @@ def main():
     if _parser.task == "plot":
         smudge_tab = smg.read_csv(args.smudgefile, sep="\t", names=["structure", "size", "rel_size"])
         cov_tab = smg.load_hetmers(args.infile)
-        smudgeplot_data = SmudgeplotData(cov_tab, smudge_tab, args.n)
+        smudgeplot_data = smg.SmudgeplotData(cov_tab, smudge_tab, args.n)
         smg.prepare_smudgeplot_data_for_plotting(smudgeplot_data, args.o, title)
         smg.smudgeplot(smudgeplot_data, log=False)
         smg.smudgeplot(smudgeplot_data, log=True)
@@ -354,6 +354,7 @@ def main():
             title,
             fmt=args.format,
             json_report=args.json_report,
+            input_params=vars(args),
         )
 
     fin()

--- a/src/smudgeplot/cli.py
+++ b/src/smudgeplot/cli.py
@@ -16,13 +16,14 @@ class Parser:
         argparser = argparse.ArgumentParser(
             # description='Inference of ploidy and heterozygosity structure using whole genome sequencing data',
             usage="""
-            smudgeplot <task> [options] \n
-            tasks: cutoff           Calculate meaningful values for lower kmer histogram cutoff.
-                   hetmers          Calculate unique kmer pairs from a FastK k-mer database.
+            smudgeplot <task> [options]
+
+            tasks: cutoff            Calculate meaningful values for lower kmer histogram cutoff.
+                   hetmers           Calculate unique kmer pairs from a FastK k-mer database.
                    peak_aggregation  Agregates smudges using local aggregation algorithm.
-                   plot             Generate 2d histogram; infere ploidy and plot a smudgeplot.
-                   all              Runs all the steps (with default options)\n\n
-                   """
+                   plot              Generate 2d histogram; infere ploidy and plot a smudgeplot.
+                   all               Runs all the steps (with default options)
+            """
         )
         # removing this for now;
         #        extract   Extract kmer pairs within specified coverage sum and minor covrage ratio ranges
@@ -214,7 +215,7 @@ class Parser:
             "--invert_cols",
             action="store_true",
             default=False,
-            help="Revert the colour palette (default False).",
+            help="Invert the colour palette (default False).",
         )
         argparser.add_argument(
             "--format",

--- a/src/smudgeplot/smudgeplot.py
+++ b/src/smudgeplot/smudgeplot.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
+import json
 import sys
 from collections import defaultdict
+from importlib.metadata import version
 from math import ceil, log
 from statistics import fmean
 
@@ -219,7 +221,7 @@ class Smudges:
             }
         )
 
-    def centrality_plot(self, output, format="pdf"):
+    def centrality_plot(self, output, fmt="pdf"):
         fig, axs = plt.subplots(figsize=(8, 8))
         fontsize = 32
         plt.plot(
@@ -231,7 +233,7 @@ class Smudges:
         )
         axs.set_xlabel("Coverage")
         axs.set_ylabel("Centrality [(theoretical_center - actual_center) / coverage ]")
-        fig.savefig(f"{output}_centralities.{format}")
+        fig.savefig(f"{output}_centralities.{fmt}")
 
 
 class SmudgeplotData:
@@ -246,6 +248,7 @@ class SmudgeplotData:
         self.fig_title = None
         self.linear_plot_file = None
         self.log_plot_file = None
+        self.json_report_file = None
 
     def calc_cov_columns(self):
         self.cov_tab["total_pair_cov"] = self.cov_tab[["covA", "covB"]].sum(axis=1)
@@ -286,7 +289,7 @@ class SmudgeplotData:
             self.lims["ylim"][1] = upper_ylim
         self.lims["xlim"] = [0, 0.5]
 
-    def def_strings(self, title=None, output="smudgeplot", format="pdf"):
+    def def_strings(self, title=None, output="smudgeplot", fmt="pdf"):
         # self.error_string = f"err = {round(self.error_fraction*100, 1)} %"
         # self.cov_string = f"1n = {self.cov}"
         if title:
@@ -294,8 +297,9 @@ class SmudgeplotData:
         else:
             fig_title = "NA"
         self.fig_title = f"{fig_title}\n1n = {self.cov:.0f}\nerr = {self.error_fraction*100:.2f}%"
-        self.linear_plot_file = f"{output}_smudgeplot_py.{format}"
-        self.log_plot_file = f"{output}_smudgeplot_log10_py.{format}"
+        self.linear_plot_file = f"{output}_smudgeplot.{fmt}"
+        self.log_plot_file = f"{output}_smudgeplot_log10.{fmt}"
+        self.json_report_file = f"{output}_smudgeplot_report.json"
 
 
 def get_centrality(smudge_container, cov, centre="mode", dist="theoretical_center"):
@@ -312,8 +316,8 @@ def get_centrality(smudge_container, cov, centre="mode", dist="theoretical_cente
             center_A, center_B = get_centre_cov_by_mode(smudge_tab)
 
         if centre == "mean":
-            center_A = sum((smudge_tab["freq"] * smudge_tab["covA"])) / kmer_in_the_smudge
-            center_B = sum((smudge_tab["freq"] * smudge_tab["covB"])) / kmer_in_the_smudge
+            center_A = sum(smudge_tab["freq"] * smudge_tab["covA"]) / kmer_in_the_smudge
+            center_B = sum(smudge_tab["freq"] * smudge_tab["covB"]) / kmer_in_the_smudge
 
         if dist == "empirical_edge":
             distA = min(
@@ -346,23 +350,62 @@ def get_centrality(smudge_container, cov, centre="mode", dist="theoretical_cente
     return fmean(centralities, weights=freqs)
 
 
-def generate_plots(smudges, coverages, cov, smudge_size_cutoff, outfile, title, format=None):
+def generate_plots(
+    smudges,
+    coverages,
+    cov,
+    smudge_size_cutoff,
+    outfile,
+    title,
+    fmt=None,
+    json_report=False,
+):
     smudges.fishnet_smudge_container = smudges.get_smudge_container(cov, smudge_size_cutoff, "fishnet")
     smudges.generate_smudge_table(smudges.fishnet_smudge_container)
 
     smudgeplot_data = SmudgeplotData(coverages.cov_tab, smudges.smudge_tab, cov, coverages.error_fraction)
-    prepare_smudgeplot_data_for_plotting(smudgeplot_data, outfile, title, format=format)
+    prepare_smudgeplot_data_for_plotting(smudgeplot_data, outfile, title, fmt=fmt)
 
     smudgeplot(smudgeplot_data, log=False)
     smudgeplot(smudgeplot_data, log=True)
 
+    if json_report:
+        write_json_report(smudgeplot_data)
 
-def prepare_smudgeplot_data_for_plotting(smudgeplot_data, output, title, format=None):
+
+def write_json_report(smg_data, min_size=0.03):
+    report = {
+        "version": version("smudgeplot"),
+        "commandline_arguments": sys.argv[1:],
+        "haploid_coverage": float(f"{smg_data.cov:.3f}"),
+        "error_fraction": smg_data.error_fraction,
+        "top_smudges": [
+            {
+                "structure": row.structure,
+                "fraction": row.rel_size,
+            }
+            for row in smg_data.smudge_tab.itertuples(index=False)
+            if row.rel_size > min_size
+        ],
+        "smudges": [
+            {
+                "structure": row.structure,
+                "count": row.size,
+                "fraction": row.rel_size,
+            }
+            for row in smg_data.smudge_tab.itertuples(index=False)
+        ],
+    }
+    with open(smg_data.json_report_file, "w") as fh:
+        fh.write(json.dumps(report, indent=2) + "\n")
+
+
+def prepare_smudgeplot_data_for_plotting(smudgeplot_data, output, title, fmt=None):
 
     smudgeplot_data.calc_cov_columns()
     smudgeplot_data.filter_cov_quant()
     smudgeplot_data.get_ax_lims()
-    smudgeplot_data.def_strings(output=output, title=title, format=format)
+    smudgeplot_data.def_strings(output=output, title=title, fmt=fmt)
 
 
 def smudgeplot(data, log=False):  # I think user arguments need to be passed here
@@ -374,9 +417,14 @@ def smudgeplot(data, log=False):  # I think user arguments need to be passed her
     )  # so things like lims can be set using user defined plotting parameters (I imagine palette will be the same although I did not try that one yet)
     fig_title = data.fig_title
 
-    fig, ((top_ax, legend_ax), (main_ax, size_ax)) = plt.subplots(nrows=2, ncols=2, width_ratios=[3, 1], height_ratios=[1, 3], figsize=(20, 20))#, sharey='row', sharex='col')
-    size_ax.sharey(main_ax), top_ax.sharex(main_ax)
-    legend_ax.axis("off"), size_ax.axis("off"), top_ax.axis("off")
+    fig, ((top_ax, legend_ax), (main_ax, size_ax)) = plt.subplots(
+        nrows=2, ncols=2, width_ratios=[3, 1], height_ratios=[1, 3], figsize=(20, 20)
+    )  # , sharey='row', sharex='col')
+    size_ax.sharey(main_ax)
+    top_ax.sharex(main_ax)
+    legend_ax.axis("off")
+    size_ax.axis("off")
+    top_ax.axis("off")
     plt.subplots_adjust(wspace=0.05, hspace=0.05)
     fontsize = 32
 
@@ -480,7 +528,7 @@ def get_one_coverage(cov_tab, cov, ax):
     lefts = (cov_row_to_plot["minor_variant_rel_cov"] - width).to_numpy()
     rights = (cov_row_to_plot["minor_variant_rel_cov"].apply(lambda x: min(0.5, x + width))).to_numpy()
     cols = cov_row_to_plot["col"].to_numpy()
-    return [get_one_box(left, right, cov, col, ax) for left, right, col in zip(lefts, rights, cols)]
+    return [get_one_box(left, right, cov, col, ax) for left, right, col in zip(lefts, rights, cols, strict=True)]
 
 
 def get_one_box(left, right, cov, colour, ax):
@@ -506,7 +554,7 @@ def plot_expected_haplotype_structure(smudge_tab, cov, ax, adjust=False, xmax=0.
 
     for index, row in smudge_tab.iterrows():
 
-        if (smudge_tab["corrected_minor_variant_cov"][index] == 0.5) & adjust:
+        if (smudge_tab["corrected_minor_variant_cov"][index] == 0.5) and adjust:
             ha = "right"
         else:
             ha = "center"
@@ -528,6 +576,7 @@ def plot_smudge_sizes(smudge_tab, cov, error_string, ax, min_size=0.03):
                 for smudge, size in zip(
                     reduce_structure_representation(smudge_tab["structure"]).to_list(),
                     round(smudge_tab["rel_size"], 2),
+                    strict=True,
                 )
             ],
             key=lambda x: x[1],
@@ -613,9 +662,9 @@ def generate_smudge_report(smudges, coverages, cov, args, smudge_size_cutoff, pr
     smudges.generate_smudge_table(smudges.local_agg_smudge_container)
 
     sys.stderr.write(
-        f'Detected smudges / sizes : \n\
-        \t {smudges.smudge_tab["structure"].to_list()} \n\
-        \t {smudges.smudge_tab["size"].to_list()} \n'
+        f"Detected smudges / sizes:\n"
+        f"  {smudges.smudge_tab['structure'].to_list()}\n"
+        f"  {smudges.smudge_tab['size'].to_list()}\n"
     )
 
     write_smudge_report(smudges, coverages, cov, args, print_header=print_header)
@@ -686,7 +735,8 @@ def cutoff(kmer_hist, boundary):
         sys.stdout.write(str(L))
     else:
         sys.stderr.write(
-            "Warning: We discourage using the original hetmer algorithm.\n\tThe updated (recommended) version does not take the argument U\n"
+            "Warning: We discourage using the original hetmer algorithm.\n"
+            "\tThe updated (recommended) version does not take the argument U\n"
         )
         # take 99.8 quantile of kmers that are more than one in the read set
         number_of_kmers = np.sum(hist[1:])

--- a/src/smudgeplot/smudgeplot.py
+++ b/src/smudgeplot/smudgeplot.py
@@ -225,7 +225,7 @@ class Smudges:
             }
         )
 
-    def centrality_plot(self, output):
+    def centrality_plot(self, output, format="pdf"):
         fig, axs = plt.subplots(figsize=(8, 8))
         fontsize = 32
         plt.plot(
@@ -237,7 +237,7 @@ class Smudges:
         )
         axs.set_xlabel("Coverage")
         axs.set_ylabel("Centrality [(theoretical_center - actual_center) / coverage ]")
-        fig.savefig(output + "_centralities.pdf")
+        fig.savefig(f"{output}_centralities.{format}")
 
 
 class SmudgeplotData:
@@ -292,7 +292,7 @@ class SmudgeplotData:
             self.lims["ylim"][1] = upper_ylim
         self.lims["xlim"] = [0, 0.5]
 
-    def def_strings(self, title=None, output="smudgeplot"):
+    def def_strings(self, title=None, output="smudgeplot", format="pdf"):
         # self.error_string = f"err = {round(self.error_fraction*100, 1)} %"
         # self.cov_string = f"1n = {self.cov}"
         if title:
@@ -300,8 +300,8 @@ class SmudgeplotData:
         else:
             fig_title = "NA"
         self.fig_title = f"{fig_title}\n1n = {self.cov:.0f}\nerr = {self.error_fraction*100:.2f}%"
-        self.linear_plot_file = output + "_smudgeplot_py.pdf"
-        self.log_plot_file = output + "_smudgeplot_log10_py.pdf"
+        self.linear_plot_file = f"{output}_smudgeplot_py.{format}"
+        self.log_plot_file = f"{output}_smudgeplot_log10_py.{format}"
 
 
 def get_centrality(smudge_container, cov, centre="mode", dist="theoretical_center"):
@@ -352,23 +352,23 @@ def get_centrality(smudge_container, cov, centre="mode", dist="theoretical_cente
     return fmean(centralities, weights=freqs)
 
 
-def generate_plots(smudges, coverages, cov, smudge_size_cutoff, outfile, title):
+def generate_plots(smudges, coverages, cov, smudge_size_cutoff, outfile, title, format=None):
     smudges.fishnet_smudge_container = smudges.get_smudge_container(cov, smudge_size_cutoff, "fishnet")
     smudges.generate_smudge_table(smudges.fishnet_smudge_container)
 
     smudgeplot_data = SmudgeplotData(coverages.cov_tab, smudges.smudge_tab, cov, coverages.error_fraction)
-    prepare_smudgeplot_data_for_plotting(smudgeplot_data, outfile, title)
+    prepare_smudgeplot_data_for_plotting(smudgeplot_data, outfile, title, format=format)
 
     smudgeplot(smudgeplot_data, log=False)
     smudgeplot(smudgeplot_data, log=True)
 
 
-def prepare_smudgeplot_data_for_plotting(smudgeplot_data, output, title):
+def prepare_smudgeplot_data_for_plotting(smudgeplot_data, output, title, format=None):
 
     smudgeplot_data.calc_cov_columns()
     smudgeplot_data.filter_cov_quant()
     smudgeplot_data.get_ax_lims()
-    smudgeplot_data.def_strings(output=output, title=title)
+    smudgeplot_data.def_strings(output=output, title=title, format=format)
 
 
 def smudgeplot(data, log=False):  # I think user arguments need to be passed here
@@ -435,7 +435,7 @@ def smudgeplot(data, log=False):  # I think user arguments need to be passed her
         #)
     )
 
-    fig.savefig(outfile, dpi=200)
+    fig.savefig(outfile, dpi=100)
     plt.close()
 
 def plot_hist(data, ax, weights, orientation='vertical', bins=50, log=False):

--- a/src/smudgeplot/smudgeplot.py
+++ b/src/smudgeplot/smudgeplot.py
@@ -359,6 +359,7 @@ def generate_plots(
     title,
     fmt=None,
     json_report=False,
+    input_params=None,
 ):
     smudges.fishnet_smudge_container = smudges.get_smudge_container(cov, smudge_size_cutoff, "fishnet")
     smudges.generate_smudge_table(smudges.fishnet_smudge_container)
@@ -370,13 +371,14 @@ def generate_plots(
     smudgeplot(smudgeplot_data, log=True)
 
     if json_report:
-        write_json_report(smudgeplot_data)
+        write_json_report(smudgeplot_data, input_params)
 
 
-def write_json_report(smg_data, min_size=0.03):
+def write_json_report(smg_data, input_params=None, min_size=0.03):
     report = {
         "version": version("smudgeplot"),
         "commandline_arguments": sys.argv[1:],
+        "input_parameters": input_params,
         "haploid_coverage": float(f"{smg_data.cov:.3f}"),
         "error_fraction": smg_data.error_fraction,
         "top_smudges": [

--- a/src/smudgeplot/smudgeplot.py
+++ b/src/smudgeplot/smudgeplot.py
@@ -1,22 +1,16 @@
 #!/usr/bin/env python3
 
 import sys
-import numpy as np
-from pandas import read_csv  # type: ignore
-from pandas import DataFrame  # type: ignore
-from pandas import Series  # type: ignore
-from pandas import concat  # type: ignore
-from numpy import arange
-from numpy import argmin
-from numpy import concatenate
-from math import log
-from math import ceil
-from statistics import fmean
 from collections import defaultdict
+from math import ceil, log
+from statistics import fmean
+
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib.collections import PatchCollection
-from itertools import product
+from numpy import arange, argmin, concatenate
+from pandas import DataFrame, Series, concat, read_csv
 
 
 class Coverages:


### PR DESCRIPTION
Also tidies import statements to standard format.

The ruff sections added to `pyproject.toml` should not affect anyone who doesn't use ruff.

Other changes are code tidying I couldn't resist, many of which will have been suggested by ruff.